### PR TITLE
Updated to Elm 0.15. Didn't update version.

### DIFF
--- a/Example.elm
+++ b/Example.elm
@@ -1,6 +1,6 @@
-import Html (Html, div, text)
-import Html.Attributes (style)
-import Flex (..)
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (style)
+import Flex exposing (..)
 
 
 ----------------------------

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.1",
+    "version": "1.0.0",
     "summary": "Flexbox layout for elm-html",
     "repository": "https://github.com/TheSeamau5/flex-html.git",
     "license": "BSD3",
@@ -10,7 +10,8 @@
         "Flex"
     ],
     "dependencies": {
-        "elm-lang/core": "1.1.1 <= v < 2.0.0",
-        "evancz/elm-html": "2.0.0 <= v < 3.0.0"
-    }
+        "elm-lang/core": "2.0.0 <= v < 3.0.0",
+        "evancz/elm-html": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.15.0 <= v < 0.16.0"
 }

--- a/src/Flex.elm
+++ b/src/Flex.elm
@@ -50,8 +50,8 @@ module Flex
 
 -}
 
-import Html (Html, div, Attribute, node)
-import Html.Attributes (style)
+import Html exposing (Html, div, Attribute, node)
+import Html.Attributes exposing (style)
 
 {-| Analog of `node`. Creates a node (of given name), with a list of styles,
 a list of attributes, and a list of children


### PR DESCRIPTION
Updated to Elm 0.15.

Kindly, note that I'm not knowledgeable about the versions in elm-package.json. But the ones written work when used as a module. And you'll surely want to look at "version" field.
