### PR TITLE
added elm-version

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,5 +12,6 @@
     "dependencies": {
         "elm-lang/core": "1.1.1 <= v < 2.0.0",
         "evancz/elm-html": "2.0.0 <= v < 3.0.0"
-    }
+    },
+    "elm-version": "0.15.0 <= v < 0.16.0"
 }


### PR DESCRIPTION
i tried to install using `elm-package install TheSeamau5/flex-html`
and i get this error:

```
Error: Unable to get elm-package.json for TheSeamau5/flex-html 1.0.1
Missing field "elm-version", acceptable versions of the Elm Platform (e.g. "0.15.0 <= v < 0.16.0").
    Check out an example elm-package.json file here:
    <https://raw.githubusercontent.com/evancz/elm-html/master/elm-package.json>
```

i added the `elm-version` on `elm-package.json`, i haven't tested it, but all projects packeges does so, should we update it?
